### PR TITLE
go.mod - use elastic in module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This contains a library function, `celfmt.Format` that can be used to canonically format CEL programs in a non-minified way and [a zero-configuration command](./cmd/celfmt) that uses that function to format CEL programs.
 
-The command can be installed with `go install github.com/efd6/celfmt/cmd/celfmt@latest`.
+The command can be installed with `go install github.com/elastic/celfmt/cmd/celfmt@latest`.
 
 `celfmt.Format` is forked from the original minifying formatter [here](https://pkg.go.dev/github.com/google/cel-go/parser#Unparse).
 

--- a/cmd/celfmt/main.go
+++ b/cmd/celfmt/main.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/efd6/celfmt"
+	"github.com/elastic/celfmt"
 	"github.com/elastic/mito/lib"
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker/decls"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/efd6/celfmt
+module github.com/elastic/celfmt
 
 go 1.22.4
 


### PR DESCRIPTION
Update module name, imports, and readme to use github.com/elastic/celfmt.

Closes #4