### PR TITLE
fix(cmd/celfmt): add decode_xml support

### DIFF
--- a/cmd/celfmt/main.go
+++ b/cmd/celfmt/main.go
@@ -183,6 +183,10 @@ func celFmtYAML(src string) (string, error) {
 type warn struct{ error }
 
 func celFmt(dst io.Writer, src string) error {
+	xmlHelper, err := lib.XML(nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to initialize xml helper: %w", err)
+	}
 	env, err := cel.NewEnv(
 		cel.Declarations(decls.NewVar("state", decls.Dyn)),
 		lib.Collections(),
@@ -196,6 +200,7 @@ func celFmt(dst io.Writer, src string) error {
 		lib.HTTP(nil, nil, nil),
 		lib.Limit(nil),
 		lib.Strings(),
+		xmlHelper,
 		cel.OptionalTypes(cel.OptionalTypesVersion(1)),
 		cel.EnableMacroCallTracking(),
 	)

--- a/cmd/celfmt/testdata/xml.txt
+++ b/cmd/celfmt/testdata/xml.txt
@@ -1,0 +1,9 @@
+celfmt -i src.cel
+! stderr .
+cmp stdout want.txt
+
+-- src.cel --
+"<?xml vers... ...>".
+decode_xml()
+-- want.txt --
+"<?xml vers... ...>".decode_xml()


### PR DESCRIPTION
Register the xml helper so that programs containing decode_xml can compile and be formatted.

Fixes #5