### PR TITLE
fix(lint): replace deprecated testscript.RunMain

### DIFF
--- a/cmd/celfmt/main_test.go
+++ b/cmd/celfmt/main_test.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"flag"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,9 +28,9 @@ import (
 var update = flag.Bool("update", false, "update testscript output files")
 
 func TestMain(m *testing.M) {
-	os.Exit(testscript.RunMain(m, map[string]func() int{
-		"celfmt": Main,
-	}))
+	testscript.Main(m, map[string]func(){
+		"celfmt": main,
+	})
 }
 
 func TestScripts(t *testing.T) {


### PR DESCRIPTION
Replace usage of 'testscript.RunMain' with 'Main'. This addresses a deprecation warning emitted by golangci-lint.

    cmd/celfmt/main_test.go:32:10: SA1019: testscript.RunMain is deprecated: use [Main],
    as the only reason for returning exit codes was to collect full code coverage,
    which Go does automatically now: https://go.dev/blog/integration-test-coverage (staticcheck)

        os.Exit(testscript.RunMain(m, map[string]func() int{
                ^