### PR TITLE
feat(docs): add godoc to exported funcs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,6 @@ jobs:
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           version: latest
-          only-new-issues: true
 
       - name: Verify go.mod and go.sum are clean
         run: |

--- a/cmd/celfmt/main.go
+++ b/cmd/celfmt/main.go
@@ -43,6 +43,8 @@ func main() {
 	os.Exit(Main())
 }
 
+// Main is the entry point for the celfmt command. It formats a CEL program
+// in a canonical format. It returns 0 on success and 1 on failure.
 func Main() int {
 	in := flag.String("i", "", "input file stdin if empty")
 	out := flag.String("o", "", "output file stdout if empty")

--- a/format.go
+++ b/format.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package celfmt provides formatting for CEL programs.
 package celfmt
 
 import (
@@ -1029,6 +1030,7 @@ type unparserOption struct {
 	alwaysComma          bool
 }
 
+// Pretty enables pretty printing of the output expression.
 func Pretty() FormatOption {
 	return func(opt *unparserOption) (*unparserOption, error) {
 		opt.pretty = true
@@ -1036,6 +1038,7 @@ func Pretty() FormatOption {
 	}
 }
 
+// AlwaysComma forces a comma to be printed after the last element of a list or map.
 func AlwaysComma() FormatOption {
 	return func(opt *unparserOption) (*unparserOption, error) {
 		opt.alwaysComma = true


### PR DESCRIPTION
Add a few bits of godoc to exported functions.

All golangci-lint issues are addressed so remove 'only-new-issues: true'.