### PR TITLE
fix(build): correct wasm generate step and file permissions

### DIFF
--- a/cmd/wasm/justfile
+++ b/cmd/wasm/justfile
@@ -4,7 +4,7 @@ default:
 
 # Run 'go generate' to copy wasm_exec.js to the assets directory.
 generate:
-    go generate -x ./...
+    GOOS=js GOARCH=wasm go generate -x ./...
 
 # Builds the assets/celfmt.wasm module.
 build:

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -54,7 +54,7 @@ import (
 	"github.com/elastic/celfmt"
 )
 
-//go:generate cp "$GOROOT/lib/wasm/wasm_exec.js" "$PWD/assets"
+//go:generate install -m 0744 "$GOROOT/lib/wasm/wasm_exec.js" "$PWD/assets"
 
 func compileAndFormat(dst io.Writer, src string) error {
 	xmlHelper, err := lib.XML(nil, nil)


### PR DESCRIPTION
The `go generate` command for the wasm build was failing for two reasons:

First, the `justfile` was missing the `GOOS=js` and `GOARCH=wasm` environment variables for the `go generate` step. This caused Go to ignore the `//go:generate` directive in `cmd/wasm/main.go` because its build constraints were not met.

Second, the command to copy `wasm_exec.js` created the destination file with read-only permissions. This caused subsequent builds to fail with a "Permission denied" error when trying to overwrite the existing file.

This change adds the required environment variables to the `justfile`'s generate recipe and ensures the copied `wasm_exec.js` is writable, making the wasm build process reliable.