### PR TITLE
cmd/celfmt: exit with non-zero status for format failure in agent mode

### DIFF
--- a/cmd/celfmt/main.go
+++ b/cmd/celfmt/main.go
@@ -136,7 +136,6 @@ func (v *visitor) VisitContent(s *ast.ContentStatement) any {
 		if err != nil {
 			if errors.As(err, &warn{}) {
 				log.Printf("did not format program field content at line %d: %s", s.Line, err)
-				return nil
 			}
 			v.err = err
 			return nil

--- a/cmd/celfmt/testdata/bad_program_yaml.txt
+++ b/cmd/celfmt/testdata/bad_program_yaml.txt
@@ -1,0 +1,7 @@
+! celfmt -agent -i src.cel
+! stdout .
+stderr 'undeclared reference to ''bad_program'''
+
+-- src.cel --
+program: |-
+  bad_program()


### PR DESCRIPTION
Please take a look.

Fixes #6