### PR TITLE
celfmt: fix comment loss in cuddled ternary else branch

### DIFF
--- a/cmd/celfmt/testdata/cuddle_comment.txt
+++ b/cmd/celfmt/testdata/cuddle_comment.txt
@@ -1,0 +1,31 @@
+celfmt -i src.cel -o out1.cel
+! stderr .
+cmp out1.cel want.txt
+
+# Verify idempotency — the original bug ate the comment on the second pass.
+celfmt -i out1.cel -o out2.cel
+! stderr .
+cmp out1.cel out2.cel
+
+-- src.cel --
+state.a ?
+	state.b
+: state.c ?
+	state.d
+:
+	// comment
+	state.e ?
+		state.f
+	:
+		state.g
+-- want.txt --
+state.a ?
+	state.b
+: state.c ?
+	state.d
+:
+	// comment
+	state.e ?
+		state.f
+	:
+		state.g

--- a/format.go
+++ b/format.go
@@ -366,7 +366,8 @@ func (un *formatter) visitCallConditional(expr ast.Expr) error {
 		un.WriteString(un.Comment(args[1].ID()))
 		un.WriteNewLine()
 		un.WriteString(":")
-		cuddle := args[2].Kind() == ast.CallKind && args[2].AsCall().FunctionName() == operators.Conditional
+		cuddle := args[2].Kind() == ast.CallKind && args[2].AsCall().FunctionName() == operators.Conditional &&
+			!un.hasCommentsForExpr(args[2].ID())
 		if cuddle {
 			un.WriteString(" ")
 		} else {


### PR DESCRIPTION
When the else branch of a ternary is itself a conditional, the formatter "cuddles" it on the same line as the colon. If that branch has a preceding comment, the comment lands inline after the colon. On a second pass the scanner sees ": // ..." which does not start with "//" so the comment is silently dropped.

Disable cuddling when the else branch has preceding comments so they get a proper line via the non-cuddled path.