### PR TITLE
cmd/celfmt: add support for the useragent global var

### DIFF
--- a/cmd/celfmt/main.go
+++ b/cmd/celfmt/main.go
@@ -217,7 +217,10 @@ func celFmt(dst io.Writer, src, indent string, simplify bool) error {
 		return fmt.Errorf("failed to initialize xml helper: %w", err)
 	}
 	env, err := cel.NewEnv(
-		cel.VariableDecls(decls.NewVariable("state", types.DynType)),
+		cel.VariableDecls(
+			decls.NewVariable("state", types.DynType),
+			decls.NewVariable("useragent", types.StringType),
+		),
 		lib.Collections(),
 		lib.Crypto(),
 		lib.JSON(nil),

--- a/cmd/celfmt/testdata/spycloud.txt
+++ b/cmd/celfmt/testdata/spycloud.txt
@@ -1,0 +1,128 @@
+celfmt -i src.cel
+! stderr .
+cmp stdout want.txt
+
+-- src.cel --
+  request(
+    "GET",
+    state.url + "/compass/data?" + {
+      ?"since": (state.?want_more.orValue(false) ? optional.none()
+      :
+        (state.?cursor.last_published_date).as(date,
+          optional.of([(date.hasValue() ?
+            timestamp(state.cursor.last_published_date)
+          :
+            now - duration(state.initial_interval)
+        ).format("2006-01-02")]))
+      ),
+      ?"cursor": state.?want_more.orValue(false) ? optional.of([state.pagination_token]) : optional.none(),
+    }.format_query()
+  ).with({
+    "Header":{
+        "x-api-key": [state.api_key],
+        "User-Agent": [useragent],
+    }
+  }).do_request().as(resp, resp.StatusCode == 200 ?
+    bytes(resp.Body).decode_json().as(body,
+      {
+        "events": (has(body.results) && body.results.size() > 0) ?
+            body.results.map(e, {"message": e.encode_json()})
+          :
+            [{"message": body.encode_json()}],
+        "cursor": {
+          ?"last_published_date": (has(body.results) && body.results.size() > 0) ?
+              optional.of(string(([?state.?cursor.last_published_date] + body.results.map(e, e.spycloud_publish_date)).map(t, timestamp(t)).max()))
+            :
+              state.?cursor.last_published_date,
+        },
+        ?"pagination_token": body.?cursor,
+        "want_more": body.?cursor.orValue("") != "",
+        "initial_interval": state.initial_interval,
+        "api_key": state.api_key,
+      }
+    )
+  :
+    {
+      "events": {
+        "error": {
+          "code": string(resp.StatusCode),
+          "id": string(resp.Status),
+          "message": "GET:"+(
+            size(resp.Body) != 0 ?
+              string(resp.Body)
+            :
+              string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+          ),
+        }
+      },
+      "want_more": false,
+      "initial_interval": state.initial_interval,
+      "api_key": state.api_key,
+    }
+  )
+-- want.txt --
+request(
+	"GET",
+	state.url + "/compass/data?" + {
+		?"since": state.?want_more.orValue(false) ?
+			optional.none()
+		:
+			state.?cursor.last_published_date.as(date,
+				optional.of(
+					[
+						(
+							date.hasValue() ?
+								timestamp(state.cursor.last_published_date)
+							:
+								now - duration(state.initial_interval)
+						).format("2006-01-02"),
+					]
+				)
+			),
+		?"cursor": state.?want_more.orValue(false) ? optional.of([state.pagination_token]) : optional.none(),
+	}.format_query()
+).with(
+	{
+		"Header": {
+			"x-api-key": [state.api_key],
+			"User-Agent": [useragent],
+		},
+	}
+).do_request().as(resp, (resp.StatusCode == 200) ?
+	bytes(resp.Body).decode_json().as(body,
+		{
+			"events": (has(body.results) && body.results.size() > 0) ?
+				body.results.map(e, {"message": e.encode_json()})
+			:
+				[{"message": body.encode_json()}],
+			"cursor": {
+				?"last_published_date": (has(body.results) && body.results.size() > 0) ?
+					optional.of(string(([?state.?cursor.last_published_date] + body.results.map(e, e.spycloud_publish_date)).map(t, timestamp(t)).max()))
+				:
+					state.?cursor.last_published_date,
+			},
+			?"pagination_token": body.?cursor,
+			"want_more": body.?cursor.orValue("") != "",
+			"initial_interval": state.initial_interval,
+			"api_key": state.api_key,
+		}
+	)
+:
+	{
+		"events": {
+			"error": {
+				"code": string(resp.StatusCode),
+				"id": string(resp.Status),
+				"message": "GET:" + (
+					(size(resp.Body) != 0) ?
+						string(resp.Body)
+					:
+						string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+				),
+			},
+		},
+		"want_more": false,
+		"initial_interval": state.initial_interval,
+		"api_key": state.api_key,
+	}
+)


### PR DESCRIPTION
This is provided in the Filebeat input and is used by some integrations. Not supporting it makes it impossible to format those integration templates.