### PR TITLE
celfmt: remap macro calls when substituting comprehensions in inlineAs

### DIFF
--- a/cmd/celfmt/testdata/simplify_as_init_comprehension.txt
+++ b/cmd/celfmt/testdata/simplify_as_init_comprehension.txt
@@ -1,0 +1,8 @@
+celfmt -s -i src.cel
+! stderr .
+cmp stdout want.txt
+
+-- src.cel --
+state.items.filter(e, e > 0).as(filtered, filtered.size())
+-- want.txt --
+state.items.filter(e, e > 0).size()

--- a/simplify.go
+++ b/simplify.go
@@ -74,7 +74,7 @@ func inlineAs(a *ast.AST) {
 			}
 
 			if n == 1 {
-				substituteIdent(result, name, init)
+				substituteIdent(result, name, init, info)
 			}
 
 			// Clear the outer .as() macro entry before any remap so we
@@ -89,7 +89,7 @@ func inlineAs(a *ast.AST) {
 			// separate tree).
 			if mcall, ok := info.GetMacroCall(result.ID()); ok {
 				if n == 1 {
-					substituteIdent(mcall, name, init)
+					substituteIdent(mcall, name, init, info)
 				}
 				info.SetMacroCall(comp.ID(), mcall)
 				info.ClearMacroCall(result.ID())
@@ -117,10 +117,17 @@ func countIdent(expr ast.Expr, ident string) int {
 }
 
 // substituteIdent replaces all IdentKind nodes named ident with replacement.
-func substituteIdent(expr ast.Expr, ident string, replacement ast.Expr) {
+// If info is non-nil and replacement has a macro call, the macro call is
+// copied to each substitution site so the formatter can find it by ID.
+func substituteIdent(expr ast.Expr, ident string, replacement ast.Expr, info *ast.SourceInfo) {
 	ast.PreOrderVisit(expr, ast.NewExprVisitor(func(e ast.Expr) {
 		if e.Kind() == ast.IdentKind && e.AsIdent() == ident {
 			e.SetKindCase(replacement)
+			if info != nil {
+				if mcall, ok := info.GetMacroCall(replacement.ID()); ok {
+					info.SetMacroCall(e.ID(), mcall)
+				}
+			}
 		}
 	}))
 }


### PR DESCRIPTION
When inlineAs substituted a comprehension (e.g. a filter) for a single-use .as() variable, the ident node took on the comprehension's content via SetKindCase but the macro call remained keyed to the original comprehension's ID. The formatter then visited the new node, found ComprehensionKind with no macro call, and errored with "unsupported expression: 2".

Pass SourceInfo to substituteIdent so it can copy the macro call from the replacement's ID to the substitution target's ID.